### PR TITLE
Fix the examples

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,10 +9,12 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:m5stack-core-esp32]
-platform = espressif32@1.1
+platform = espressif32@3.4.0
 board = m5stack-core-esp32
 framework = arduino
 upload_speed = 921600
+monitor_speed = 115200
+
 ; targets = upload
 
 ; board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
The examples do not compile anymore in PIO.

Setting the platform version to 3.4.0 fixes this.